### PR TITLE
Remove comments in glsl code from builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^2.6.2",
     "rollup": "^0.59.1",
     "rollup-plugin-babel": "^3.0.7",
-    "rollup-plugin-glsl": "^1.2.0",
+    "rollup-plugin-glsl": "git+https://github.com/WorldThirteen/rollup-plugin-glsl.git#dist",
     "rollup-plugin-json": "^3.0.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-uglify": "^3.0.0",


### PR DESCRIPTION
Results for es.min.js: 96kb -> 87kb (~9.4% size reducing).
We want to provide as lightweight build as possible, so I propose to remove comments (including copyrights) of glsl code from builds.