### PR TITLE
Remove extra logging from test output

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,6 +18,10 @@ module.exports = function makeConfig(config) {
       'karma-chrome-launcher',
     ],
     webpack: webpackConfig,
+    webpackMiddleware: {
+      stats: 'errors-only',
+      logLevel: 'error',
+    },
     customLaunchers: {
       ChromeHeadlessWithGPU: {
         base: 'ChromeHeadless',
@@ -28,5 +32,6 @@ module.exports = function makeConfig(config) {
         ],
       },
     },
+    logLevel: config.LOG_WARN,
   });
 };


### PR DESCRIPTION
Set logging levels:
- weback: errors
- webpack-middleware: errors
- karma: warnings

After this PR:
```
HeadlessChrome 0.0.0 (Mac OS X 10.12.6): Executed 156 of 156 SUCCESS (20.953 secs / 19.622 secs)
```

Before this PR:
```
ℹ ｢wdm｣: Hash: 664611c15cbd9b47ab0f
Version: webpack 3.12.0
Time: 304ms
ℹ ｢wdm｣: Compiled successfully.
ℹ ｢wdm｣: Compiling...
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: wait until bundle finished: noop
ℹ ｢wdm｣: Hash: 24a39be0d0371af5da00
Version: webpack 3.12.0
Time: 6917ms
                                  Asset     Size  Chunks                    Chunk Names
             test/ops/threshold.spec.js  1.81 MB      11  [emitted]  [big]  test/ops/threshold.spec.js
                        test/io.spec.js  12.4 MB       0  [emitted]  [big]  test/io.spec.js
                 test/ops/erode.spec.js  1.82 MB       2  [emitted]  [big]  test/ops/erode.spec.js
                test/ops/dilate.spec.js  1.82 MB       3  [emitted]  [big]  test/ops/dilate.spec.js
              test/ops/upsample.spec.js  1.83 MB       4  [emitted]  [big]  test/ops/upsample.spec.js
             test/ops/grayscale.spec.js  4.16 MB       5  [emitted]  [big]  test/ops/grayscale.spec.js
                  test/ops/cast.spec.js  3.29 MB       6  [emitted]  [big]  test/ops/cast.spec.js
    test/ops/adaptive_threshold.spec.js  2.83 MB       7  [emitted]  [big]  test/ops/adaptive_threshold.spec.js
     test/ops/summed_area_table.spec.js  1.81 MB       8  [emitted]  [big]  test/ops/summed_area_table.spec.js
           test/program/session.spec.js  1.83 MB       9  [emitted]  [big]  test/program/session.spec.js
         test/program/operation.spec.js  1.81 MB      10  [emitted]  [big]  test/program/operation.spec.js
         test/ops/morphology_ex.spec.js  1.87 MB       1  [emitted]  [big]  test/ops/morphology_ex.spec.js
                   test/ops/sub.spec.js  1.81 MB      12  [emitted]  [big]  test/ops/sub.spec.js
                  test/ops/math.spec.js  1.82 MB      13  [emitted]  [big]  test/ops/math.spec.js
                     test/utils.spec.js  1.74 MB      14  [emitted]  [big]  test/utils.spec.js
      test/program/tensor_utils.spec.js  1.75 MB      15  [emitted]  [big]  test/program/tensor_utils.spec.js
            test/program/tensor.spec.js  1.75 MB      16  [emitted]  [big]  test/program/tensor.spec.js
test/program/operation_register.spec.js  1.75 MB      17  [emitted]  [big]  test/program/operation_register.spec.js
test/program/kernel_constructor.spec.js  1.74 MB      18  [emitted]  [big]  test/program/kernel_constructor.spec.js
                test/ops/conv2d.spec.js   2.4 MB      19  [emitted]  [big]  test/ops/conv2d.spec.js
             test/ops/histogram.spec.js   850 kB      20  [emitted]  [big]  test/ops/histogram.spec.js
        test/program/graph_node.spec.js  6.01 kB      21  [emitted]         test/program/graph_node.spec.js
 [293] ./test/ops/math.spec.js 7.15 kB {13} [built]
 [294] ./test/ops/histogram.spec.js 2.52 kB {20} [built]
 [295] ./test/ops/morphology_ex.spec.js 12.8 kB {1} [built]
 [306] ./test/ops/summed_area_table.spec.js 3.98 kB {8} [built]
 [308] ./test/ops/sub.spec.js 1.68 kB {12} [built]
 [309] ./test/ops/threshold.spec.js 3.17 kB {11} [built]
 [310] ./test/program/graph_node.spec.js 0 bytes {21} [built]
 [311] ./test/ops/upsample.spec.js 2.94 kB {4} [built]
 [315] ./test/program/kernel_constructor.spec.js 3.42 kB {18} [built]
 [316] ./test/program/operation_register.spec.js 7.56 kB {17} [built]
 [317] ./test/program/operation.spec.js 3.5 kB {10} [built]
 [318] ./test/program/session.spec.js 8.19 kB {9} [built]
 [319] ./test/program/tensor.spec.js 4.41 kB {16} [built]
 [320] ./test/utils.spec.js 2.93 kB {14} [built]
 [321] ./test/program/tensor_utils.spec.js 6.06 kB {15} [built]
    + 307 hidden modules
ℹ ｢wdm｣: Compiled successfully.
12 08 2018 18:27:34.427:INFO [karma]: Karma v2.0.2 server started at http://0.0.0.0:9876/
12 08 2018 18:27:34.429:INFO [launcher]: Launching browser ChromeHeadlessWithGPU with unlimited concurrency
12 08 2018 18:27:34.537:INFO [launcher]: Starting browser ChromeHeadless
12 08 2018 18:27:35.263:INFO [HeadlessChrome 0.0.0 (Mac OS X 10.12.6)]: Connected on socket g0ZvudZEThMXpoaeAAAA with id 15910090
HeadlessChrome 0.0.0 (Mac OS X 10.12.6): Executed 156 of 156 SUCCESS (21.195 secs / 20.048 secs)
```