### PR TITLE
Fix Safari sub-pixel requesting in pcLines transform operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+# [Unreleased]
+### Fixed
+- PCLines operation extra lines bug on Safari (part of https://github.com/PeculiarVentures/GammaCV/issues/25)
+
 ## [0.3.0] - 2018-08-29
 ### Added
 - Export internal PCLines functions:

--- a/lib/ops/pclines/transform.glsl
+++ b/lib/ops/pclines/transform.glsl
@@ -103,7 +103,7 @@ float getValue(float i, float lx, float ly, vec4 side) {
   }
 
   if (xx > 0.0 && xx < uWidth && yy > 0.0 && yy < uHeight) {
-    float a = pickScalarValue_tSrc(yy, xx);
+    float a = pickScalarValue_tSrc(floor(yy), floor(xx));
 
     if (a > 0.0) {
       return 1.0;


### PR DESCRIPTION
Related to https://github.com/PeculiarVentures/GammaCV/issues/25

This change doesn't enhance the floating precision on iOS devices.
This change fixes detection of extra, not existed lines, example:
![image](https://user-images.githubusercontent.com/14346393/46909695-4a39ee80-cf3f-11e8-8838-2e76587b7546.png)
(notice the diagonal lines)

Was reproduced on Desktop Safari11.0, Safari 12.0 and iOS Safari 12.0.
The fix was tested on Desktop Safari 12.0 and iOS Safari 12.0.