### PR TITLE
Fix PCLinesReduceMax op and floats precision on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-# [0.3.1] - 2018-10-14
+## Unreleased
+### Fixed
+- Enhance precision of floats encode/decode on iOS devices
+
+
+## [0.3.1] - 2018-10-14
 ### Fixed
 - PCLines operation extra lines bug on Safari (part of https://github.com/PeculiarVentures/GammaCV/issues/25)
 

--- a/app/src/examples/pc_lines.js
+++ b/app/src/examples/pc_lines.js
@@ -10,7 +10,7 @@ export default {
     pipeline = gm.gaussianBlur(pipeline, 3, 3);
     pipeline = gm.sobelOperator(pipeline);
     pipeline = gm.cannyEdges(pipeline, 0.25, 0.75);
-    pipeline = gm.pcLines(pipeline, params.PCLINES.layers, 2);
+    pipeline = gm.pcLines(pipeline, params.PCLINES.layers, 2, 2);
 
     return pipeline;
   },
@@ -25,10 +25,10 @@ export default {
 
     for (let i = 0; i < output.size / 4; i += 1) {
       const y = ~~(i / output.shape[1]);
-      const x = i - (y * output.shape[0]);
-      const value = output.get(x, y, 0);
-      const x0 = output.get(x, y, 1);
-      const y0 = output.get(x, y, 2);
+      const x = i - (y * output.shape[1]);
+      const value = output.get(y, x, 0);
+      const x0 = output.get(y, x, 1);
+      const y0 = output.get(y, x, 2);
 
       if (value > 0.0) {
         lines.push([value, x0, y0]);

--- a/lib/ops/pclines/index.js
+++ b/lib/ops/pclines/index.js
@@ -11,21 +11,25 @@ import transformKernel from './transform.glsl';
 import enhanceKernel from './enhance.glsl';
 import peaksKernel from './peaks.glsl';
 
-export const pcLinesReduceMax = (tSrc, k = 10, f = 0) => new RegisterOperation('ReduceMax')
-  .Input('tSrc', 'uint8')
-  .Output('float32')
-  .Uniform('uSrcWidth', 'float', tSrc.shape[1])
-  .Uniform('uWidth', 'float', tSrc.shape[1] / k)
-  .Uniform('uHeight', 'float', tSrc.shape[0] / k)
-  .Uniform('uF', 'float', f)
-  .LoadChunk('pickValue')
-  .Constant('SIZE', ~~(tSrc.shape[0] / k) * ~~(tSrc.shape[1] / k))
-  .Constant('W', k)
-  .Constant('H', k)
-  .Constant('K', 1 / k)
-  .SetShapeFn(() => [~~(tSrc.shape[0] / k), ~~(tSrc.shape[1] / k), 4])
-  .GLSLKernel(peaksKernel)
-  .Compile({ tSrc });
+export const pcLinesReduceMax = (tSrc, k = 10, f = 0) => {
+  const h = ~~(tSrc.shape[0] / k);
+  const w = ~~(tSrc.shape[1] / k);
+  const _k = Math.ceil(Math.max(tSrc.shape[0] / h, tSrc.shape[1] / w));
+
+  return new RegisterOperation('ReduceMax')
+    .Input('tSrc', f ? 'float32' : 'uint8')
+    .Output('float32')
+    .Uniform('uF', 'float', f)
+    .LoadChunk('pickValue')
+    .Constant('W', _k)
+    .Constant('H', _k)
+    .Constant('O_WIDTH', tSrc.shape[1])
+    .Constant('O_HEIGHT', tSrc.shape[0])
+    .Constant('K', 1 / _k)
+    .SetShapeFn(() => [Math.ceil(tSrc.shape[0] / _k), Math.ceil(tSrc.shape[1] / _k), 4])
+    .GLSLKernel(peaksKernel)
+    .Compile({ tSrc });
+};
 
 export const pcLinesEnhance = tSrc => new RegisterOperation('PCLinesEnhanced')
   .Input('tSrc', 'uint8')

--- a/lib/ops/pclines/peaks.glsl
+++ b/lib/ops/pclines/peaks.glsl
@@ -10,28 +10,31 @@ const int w = int(W);
 const int h = int(H);
 
 vec4 operation(float _y, float _x) {
-  float sum = 0.0;
   float mmax = 0.0;
   float maxX = 0.0;
   float maxY = 0.0;
   float sy = _y * H;
   float sx = _x * W;
+  float yLimit = O_HEIGHT - sy;
+  float xLimit = O_WIDTH - sx;
+  vec4 value;
 
-  for (int x = 0; x < w; x += 1) {
-    for (int y = 0; y < h; y += 1) {
-      vec4 value;
-      if (uWidth == uSrcWidth) {
-        value = pickValue_tSrc(_y, _x);
-      } else {
-        value = pickValue_tSrc(float(y) + sy, float(x) + sx);
+  for (float y = 0.0; y < H; y += 1.0) {
+    if (y >= yLimit) {
+      break;
+    }
+    for (float x = 0.0; x < W; x += 1.0) {
+      if (x >= xLimit) {
+        break;
       }
+      value = pickValue_tSrc(y + sy, x + sx);
 
-      if (value.r > mmax) {
+      if (value.r >= mmax) {
         mmax = value.r;
 
-        if (uF == 0.0) {
-          maxX = float(x) + sx;
-          maxY = float(y) + sy;
+        if (uF < 0.5) {
+          maxX = x + sx;
+          maxY = y + sy;
         } else {
           maxX = value.g;
           maxY = value.b;

--- a/lib/program/glsl/chunks/float.glsl
+++ b/lib/program/glsl/chunks/float.glsl
@@ -12,12 +12,11 @@ highp vec4 encode_float(highp float f) {
   highp float e =5.0;
   highp float F = abs(f); 
   highp float sign = step(0.0,-f);
-  highp float exponent = floor(log2(F)); 
+  highp float exponent = floor(log2(F));
   highp float mantissa = (exp2(- exponent) * F);
   exponent = floor(log2(F) + 127.0) + floor(log2(mantissa));
   rgba[0] = 128.0 * sign + floor(exponent * exp2(-1.0));
   rgba[1] = 128.0 * mod(exponent, 2.0) + mod(floor(mantissa * 64.0 * 2.0), 128.0);  
-  // rgba[1] = f;
   rgba[2] = floor(mod(floor(mantissa * exp2(23.0 -8.0)), exp2(8.0)));
   rgba[3] = floor(exp2(23.0) * mod(mantissa, exp2(-15.0)));
 
@@ -28,17 +27,12 @@ float decode_float(highp vec4 rgba) {
   rgba = rgba.abgr * 255.0;
   highp float sign = 1.0 - step(128.0,rgba[0])*2.0;
   highp float exponent = 2.0 * mod(rgba[0],128.0) + step(128.0,rgba[1]) - 127.0; 
+  exponent = floor(exponent + 0.5);
   highp float mantissa = mod(rgba[1],128.0)*32768.0 * 2.0 + rgba[2]*256.0 +rgba[3] + float(0x800000);
   highp float result = sign
     * mantissa
-    * exp2(-6.0)
-    * exp2(exponent / 4.0)
-    * exp2(-7.0)
-    * exp2(exponent / 4.0)
-    * exp2(-5.0)
-    * exp2(exponent / 4.0)
-    * exp2(-5.0)
-    * exp2(exponent / 4.0);
+    * exp2(-23.0)
+    * exp2(exponent);
 
   return result;
 }


### PR DESCRIPTION
- Enhance precision of floats encode/decode on iOS devices
- Fix pick output shape of the pcLinesReduceMax operation
- Update pcLinesReduceMax glsl kernel (cleanup, prevent requesting out of texture bounds)