### PR TITLE
WEBRTC requested ratio fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Fixed
+- Fix the requested ratio for webrtc video
+
 ## [0.3.2] - 2018-10-21
 ### Added
 - Squared summed area table operation `gm.sqsat`

--- a/lib/io/video.js
+++ b/lib/io/video.js
@@ -185,7 +185,7 @@ export class CaptureVideo {
       video: {
         width: { min: 240, ideal: 1080, max: 1920 },
         height: { min: 240, ideal: 1080, max: 1920 },
-        aspectRatio: { exact: this.width / this.height },
+        aspectRatio: { exact: this.height / this.width },
         deviceId: deviceID ? { ideal: deviceID } : undefined,
         facingMode: exactFacingMode ? { exact: exactFacingMode } : null,
       },


### PR DESCRIPTION
This PR provide a fix for a bug with requesting incorrect ratio constraint for the WEBRTC video stream.