### PR TITLE
Change requesting aspectRatio logic on android devices

### DIFF
--- a/lib/io/video.js
+++ b/lib/io/video.js
@@ -185,13 +185,22 @@ export class CaptureVideo {
       video: {
         width: { min: 240, ideal: 1080, max: 1920 },
         height: { min: 240, ideal: 1080, max: 1920 },
-        aspectRatio: { exact: this.height / this.width },
+        aspectRatio: { exact: this.width / this.height },
         deviceId: deviceID ? { ideal: deviceID } : undefined,
         facingMode: exactFacingMode ? { exact: exactFacingMode } : null,
       },
     };
 
     const ua = navigator.userAgent;
+
+    const isPortrait =
+      !(window.orientation === -90
+      || window.orientation === 90
+      || window.offsetWidth > window.offsetHeight);
+
+    if (/android/i.test(ua) && isPortrait) {
+      cfg.video.aspectRatio.exact = 1 / cfg.video.aspectRatio.exact;
+    }
 
     if (ua.indexOf('Safari') !== -1 && ua.indexOf('Chrome') === -1) {
       delete cfg.video.width;


### PR DESCRIPTION
Make spacial logic for requesting WEBRTC video stream on android devices with portrait orientation.
Android chrome inverts the aspect ratio constraint

This is an addition to the https://github.com/PeculiarVentures/GammaCV/pull/30.
