### PR TITLE
Set image.crossOrigin before setting image.src

### DIFF
--- a/lib/io/image.js
+++ b/lib/io/image.js
@@ -18,10 +18,8 @@ export function imageTensorFromURL(url, type = 'uint8', outShape, cors = false) 
     let width;
     let height;
 
-    image.src = url;
-
     if (cors) {
-      image.crossOrigin = 'Anonimus';
+      image.crossOrigin = 'anonymous';
     }
 
     image.onload = () => {
@@ -59,5 +57,7 @@ export function imageTensorFromURL(url, type = 'uint8', outShape, cors = false) 
     };
 
     image.onerror = reject;
+
+    image.src = url;
   });
 }


### PR DESCRIPTION
This resolves the "tainted canvas" issue in CORS scenarios; [`crossOrigin` must be set before `src`](https://stackoverflow.com/questions/23123237/drawing-images-to-canvas-with-img-crossorigin-anonymous-doesnt-work). Also, corrected the spelling of "anonymous".