### PR TITLE
WebGL assertion fix

### DIFF
--- a/lib/program/session.js
+++ b/lib/program/session.js
@@ -30,12 +30,14 @@ export default class Session {
   initWebGL(canvas, opts) {
     this.canvas = canvas;
     const gl = this.canvas.getContext('webgl', opts);
-    const float32Ext = gl.getExtension('OES_texture_float');
 
     utils.assert(
       !!gl,
       'Session: WebGL not supported.',
     );
+
+    const float32Ext = gl.getExtension('OES_texture_float');
+
     utils.assert(
       !!float32Ext,
       'Session: Unable to find extension OES_texture_float',


### PR DESCRIPTION
Previously, in case of no WebGL in browser, user received error `Cannot read property getExtensions of null`.
It made error identification hard.

This changes makes `initWebGL` method to assert WebGL and throws error of no `WebGL` before attempting to get `OES_texture_float` extension.