### PR TITLE
Replace eval with new Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Changed
+- Replace `eval` with `new Function` in tensor utils `gm.tensorInvert` and `gm.flipTensor`
+
 ## [0.4.1] - 2020-12-23
 ### Fixed
 - Assertion for WebGL availability (https://github.com/PeculiarVentures/GammaCV/pull/77)

--- a/lib/program/tensor_utils.js
+++ b/lib/program/tensor_utils.js
@@ -69,13 +69,11 @@ export function tensorInvert(
   }
 
   const tmpArr = new Array(shape.length); // eslint-disable-line
-  let invert = () => { }; // eslint-disable-line
-
-  eval(`invert = function (coords) { ${invertShape.map((a, key) => a ? `tmpArr[${key}] = shape[${key}] - 1 - coords[${key}]` : `tmpArr[${key}] = coords[${key}]`).join(';')}; return tmpArr; }`); // eslint-disable-line
+  const invert = new Function('coords', 'tmpArr', 'shape', `${invertShape.map((a, key) => a ? `tmpArr[${key}] = shape[${key}] - 1 - coords[${key}]` : `tmpArr[${key}] = coords[${key}]`).join(';')}; return tmpArr;`); // eslint-disable-line
 
   for (let i = 0; i < input.size; i += 1) {
     const coords = Tensor.IndexToCoord(shape, i);
-    const inverted = invert(coords, tmpArr);
+    const inverted = invert(coords, tmpArr, shape);
 
     output.set(...inverted, input.get(...coords));
   }
@@ -150,13 +148,11 @@ export function flipTensor(
   }
 
   const tmpArr = new Array(shape.length); // eslint-disable-line
-  let invert = () => { }; // eslint-disable-line
-
-  eval(`invert = function (coords) { ${invertShape.map((a, key) => a ? `tmpArr[${key}] = shape[${key}] - 1 - coords[${key}]` : `tmpArr[${key}] = coords[${key}]`).join(';')}; return tmpArr; }`); // eslint-disable-line
+  const invert = new Function('coords', 'tmpArr', 'shape', `${invertShape.map((a, key) => a ? `tmpArr[${key}] = shape[${key}] - 1 - coords[${key}]` : `tmpArr[${key}] = coords[${key}]`).join(';')}; return tmpArr;`); // eslint-disable-line
 
   for (let i = 0; i < input.size; i += 1) {
     const coords = Tensor.IndexToCoord(shape, i);
-    const inverted = invert(coords, tmpArr);
+    const inverted = invert(coords, tmpArr, shape);
 
     output.set(...inverted, input.get(...coords));
   }


### PR DESCRIPTION
Fixes #75.

This change does not negatively affect performance.
<details>
  <summary>Benchmark</summary>

```
Tensor 2x2
eval x 142,601 ops/sec ±1.47% (87 runs sampled)
new Function x 142,798 ops/sec ±0.54% (92 runs sampled)
Fastest is new Function
```

```
Tensor 200 x 200 x 200
eval x 0.39 ops/sec ±2.86% (5 runs sampled)
new Function x 0.42 ops/sec ±1.84% (6 runs sampled)
Fastest is new Function
```
</details>