### PR TITLE
Override version of 2nd order dev-dependency to treat security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9355,19 +9355,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -10169,7 +10156,7 @@
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
+        "json5": "2.2.2",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
@@ -15240,7 +15227,7 @@
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
-        "json5": "^2.1.2"
+        "json5": "2.2.2"
       }
     },
     "locate-path": {
@@ -17276,21 +17263,9 @@
       "peer": true,
       "requires": {
         "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "2.2.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "minimist": "^1.2.0"
-          }
-        }
       }
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "url-loader": "^4.1.1",
     "webpack": "^5.75.0"
   },
+  "overrides": {
+    "json5": "2.2.2"
+  },
   "files": [
     "LICENSE.md",
     "README.md",


### PR DESCRIPTION
The `json5` package has been updated since the old version contains `High` Severity vulnerability `CVE-2022-46175`.

The "override" was used since part of dev-deps tree wasn't updated to support the major version with required patch:

Part of the output for `npm ls json5`
```
└─┬ eslint-config-airbnb@19.0.4
  └─┬ eslint-plugin-import@2.26.0
    └─┬ tsconfig-paths@3.14.1
      └── json5@1.0.2
```

Since this is a dev-dependency, library release is not required.