### PR TITLE
App: Add redirect from docs index to get started

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -27,4 +27,13 @@ module.exports = {
 
     return config;
   },
+  async redirects() {
+    return [
+      {
+        source: '/docs',
+        destination: '/docs/get_started',
+        permanent: false,
+      },
+    ];
+  },
 };


### PR DESCRIPTION
Currently, README in GammaCV contains a link to docs root, which respond with 404. This fixed it by redirecting to get started section.
