### PR TITLE
CI: Update browser install orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.2
 
 aliases:
   - &docker-node-browsers


### PR DESCRIPTION
CI failed on the master, so it requires this update to continue operating.